### PR TITLE
Omf3 pr 05 business

### DIFF
--- a/omf3/libs/business/README.md
+++ b/omf3/libs/business/README.md
@@ -1,0 +1,39 @@
+# libs/business
+
+Derived, reactive aggregates that sit on top of the MQTT gateway stream.
+
+## Usage
+
+```ts
+import { createBusiness } from '@omf3/business';
+import { createGateway } from '@omf3/gateway';
+import { Subject } from 'rxjs';
+
+const rawMessages$ = new Subject<{ topic: string; payload: unknown }>();
+const gateway = createGateway(rawMessages$.asObservable());
+const business = createBusiness(gateway);
+
+business.orderCounts$.subscribe((counts) => console.log(counts));
+```
+
+### Exposed streams
+
+- `orderCounts$` – number of orders by status (`running`, `queued`, `completed`)
+- `stockByPart$` – cumulative stock level per part id
+- `moduleStates$` – latest state per module id
+- `ftsStates$` – latest FTS state per id
+
+All streams are `shareReplay(1)` so late subscribers receive the current value immediately.
+
+## Testing
+
+```bash
+npx nx test business
+npx nx build business   # optional TypeScript build
+```
+
+## Notes
+
+- Business logic stays framework neutral; it only consumes the typed gateway interface.
+- Add more derived streams (alerts, KPIs, etc.) in this library to keep Angular components thin.
+

--- a/omf3/libs/business/project.json
+++ b/omf3/libs/business/project.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "name": "business",
+  "projectType": "library",
+  "root": "omf3/libs/business",
+  "sourceRoot": "omf3/libs/business/src",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/business",
+        "tsConfig": "omf3/libs/business/tsconfig.lib.json",
+        "main": "omf3/libs/business/src/index.ts",
+        "assets": []
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsx omf3/libs/business/src/__tests__/business.spec.ts"
+      }
+    }
+  },
+  "tags": ["scope:shared", "type:lib"]
+}
+

--- a/omf3/libs/business/src/__tests__/business.spec.ts
+++ b/omf3/libs/business/src/__tests__/business.spec.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { Subject, firstValueFrom } from 'rxjs';
+import { skip } from 'rxjs/operators';
+
+import { createBusiness, type GatewayStreams } from '@omf3/business';
+import type {
+  FtsState,
+  ModuleState,
+  OrderActive,
+  StockMessage,
+} from '@omf3/entities';
+
+const subject = <T>() => new Subject<T>();
+
+const createGateway = (): {
+  streams: GatewayStreams;
+  subjects: {
+    orders$: Subject<OrderActive>;
+    stock$: Subject<StockMessage>;
+    modules$: Subject<ModuleState>;
+    fts$: Subject<FtsState>;
+  };
+} => {
+  const orders$ = subject<OrderActive>();
+  const stock$ = subject<StockMessage>();
+  const modules$ = subject<ModuleState>();
+  const fts$ = subject<FtsState>();
+
+  return {
+    streams: {
+      orders$: orders$.asObservable(),
+      stock$: stock$.asObservable(),
+      modules$: modules$.asObservable(),
+      fts$: fts$.asObservable(),
+    },
+    subjects: {
+      orders$,
+      stock$,
+      modules$,
+      fts$,
+    },
+  };
+};
+
+test('aggregates order counts', async () => {
+  const { streams, subjects } = createGateway();
+  const business = createBusiness(streams);
+
+  const countsPromise = firstValueFrom(business.orderCounts$.pipe(skip(3)));
+
+  subjects.orders$.next({ orderId: 'o1', productId: 'A', quantity: 1, status: 'running' });
+  subjects.orders$.next({ orderId: 'o2', productId: 'B', quantity: 2, status: 'queued' });
+  subjects.orders$.next({ orderId: 'o3', productId: 'C', quantity: 1, status: 'completed' });
+
+  const counts = await countsPromise;
+  assert.equal(counts.running, 1);
+  assert.equal(counts.queued, 1);
+  assert.equal(counts.completed, 1);
+});
+
+test('summarises stock per part', async () => {
+  const { streams, subjects } = createGateway();
+  const business = createBusiness(streams);
+
+  const levelsPromise = firstValueFrom(business.stockByPart$.pipe(skip(2)));
+
+  subjects.stock$.next({ moduleId: 'm1', partId: 'PARTX', amount: 10 });
+  subjects.stock$.next({ moduleId: 'm1', partId: 'PARTX', amount: 20 });
+
+  const levels = await levelsPromise;
+  assert.equal(levels.PARTX, 30);
+});
+
+test('captures latest module and fts states', async () => {
+  const { streams, subjects } = createGateway();
+  const business = createBusiness(streams);
+
+  const modulePromise = firstValueFrom(business.moduleStates$.pipe(skip(1)));
+  const ftsPromise = firstValueFrom(business.ftsStates$.pipe(skip(1)));
+
+  subjects.modules$.next({ moduleId: 'SVR3QA0022', state: 'working' });
+  subjects.fts$.next({ ftsId: '5iO4', status: 'moving' });
+
+  const moduleStates = await modulePromise;
+  const ftsStates = await ftsPromise;
+
+  assert.equal(moduleStates.SVR3QA0022?.state, 'working');
+  assert.equal(ftsStates['5iO4']?.status, 'moving');
+});
+

--- a/omf3/libs/business/src/index.ts
+++ b/omf3/libs/business/src/index.ts
@@ -1,0 +1,111 @@
+import { Observable } from 'rxjs';
+import { map, scan, shareReplay, startWith } from 'rxjs/operators';
+
+import type {
+  FtsState,
+  ModuleState,
+  OrderActive,
+  StockMessage,
+} from '@omf3/entities';
+
+export interface GatewayStreams {
+  orders$: Observable<OrderActive>;
+  stock$: Observable<StockMessage>;
+  modules$: Observable<ModuleState>;
+  fts$: Observable<FtsState>;
+}
+
+export interface BusinessStreams {
+  orderCounts$: Observable<Record<'running' | 'queued' | 'completed', number>>;
+  stockByPart$: Observable<Record<string, number>>;
+  moduleStates$: Observable<Record<string, ModuleState>>;
+  ftsStates$: Observable<Record<string, FtsState>>;
+}
+
+export const createBusiness = (gateway: GatewayStreams): BusinessStreams => {
+  const ordersState$ = gateway.orders$.pipe(
+    scan(
+      (acc, order) => {
+        if (!order.orderId) {
+          return acc;
+        }
+
+        return { ...acc, [order.orderId]: order };
+      },
+      {} as Record<string, OrderActive>
+    ),
+    startWith({} as Record<string, OrderActive>),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
+
+  const orderCounts$ = ordersState$.pipe(
+    map((orders) => {
+      const counts = {
+        running: 0,
+        queued: 0,
+        completed: 0,
+      };
+
+      Object.values(orders).forEach((order) => {
+        if (order.status === 'running') counts.running += 1;
+        if (order.status === 'queued') counts.queued += 1;
+        if (order.status === 'completed') counts.completed += 1;
+      });
+
+      return counts;
+    }),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
+
+  const stockByPart$ = gateway.stock$.pipe(
+    scan(
+      (acc, msg) => {
+        if (!msg.partId) {
+          return acc;
+        }
+
+        const next = { ...acc };
+        next[msg.partId] = (next[msg.partId] ?? 0) + (msg.amount ?? 0);
+        return next;
+      },
+      {} as Record<string, number>
+    ),
+    startWith({} as Record<string, number>),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
+
+  const moduleStates$ = gateway.modules$.pipe(
+    scan(
+      (acc, module) => {
+        if (!module.moduleId) {
+          return acc;
+        }
+
+        return { ...acc, [module.moduleId]: module };
+      },
+      {} as Record<string, ModuleState>
+    ),
+    startWith({} as Record<string, ModuleState>),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
+
+  const ftsStates$ = gateway.fts$.pipe(
+    scan(
+      (acc, fts) => {
+        const id = fts.ftsId ?? 'unknown';
+        return { ...acc, [id]: fts };
+      },
+      {} as Record<string, FtsState>
+    ),
+    startWith({} as Record<string, FtsState>),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
+
+  return {
+    orderCounts$,
+    stockByPart$,
+    moduleStates$,
+    ftsStates$,
+  };
+};
+

--- a/omf3/libs/business/tsconfig.lib.json
+++ b/omf3/libs/business/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc/business",
+    "declaration": true,
+    "types": []
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts"]
+}
+

--- a/omf3/libs/business/tsconfig.spec.json
+++ b/omf3/libs/business/tsconfig.spec.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}
+

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,7 +15,8 @@
     "paths": {
       "@omf3/entities": ["omf3/libs/entities/src/index.ts"],
       "@omf3/mqtt-client": ["omf3/libs/mqtt-client/src/index.ts"],
-      "@omf3/gateway": ["omf3/libs/gateway/src/index.ts"]
+      "@omf3/gateway": ["omf3/libs/gateway/src/index.ts"],
+      "@omf3/business": ["omf3/libs/business/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## Summary
- introduce the Nx workspace targets for `libs/business`
- expose reactive aggregates on top of the gateway (orderCounts$, stockByPart$, moduleStates$, ftsStates$)
- add unit tests with RxJS subjects and usage documentation

## Testing
- npm install
- npx nx test business
- npx nx build business